### PR TITLE
fix wrong version information

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,7 +16,7 @@ builds:
     binary: schemalex-deploy
     ldflags:
       - -s -w
-      - -X github.com/shogo82148/schemalex-deploy.version={{.Version}}
+      - -X github.com/shogo82148/schemalex-deploy.Version={{.Version}}
   - id: "cli-arm64"
     env:
       - CGO_ENABLED=0

--- a/cmd/schemalex-deploy/schemalex-deploy.go
+++ b/cmd/schemalex-deploy/schemalex-deploy.go
@@ -98,7 +98,7 @@ schemalex -version
 
 func showVersion() {
 	fmt.Printf(
-		"schemalex-deploy version %s, built with go %s for %s/%s\n",
+		"schemalex-deploy version %s, built with %s for %s/%s\n",
 		getVersion(),
 		runtime.Version(),
 		runtime.GOOS,


### PR DESCRIPTION
I use the binary built using goreleaser.
Its version information is `version (devel)`.

```
% ./schemalex-deploy -version
schemalex-deploy version (devel), built with go go1.16.6 for darwin/amd64
```

It should be `version 0.0.1`.