### PR TITLE
Fix mysql.Config.Addr is not working

### DIFF
--- a/cmd/schemalex-deploy/schemalex-deploy.go
+++ b/cmd/schemalex-deploy/schemalex-deploy.go
@@ -41,6 +41,7 @@ func _main() error {
 	defer stop()
 
 	config := mysql.NewConfig()
+	config.Net = "tcp"
 	config.Addr = net.JoinHostPort(cfn.host, strconv.Itoa(cfn.port))
 	config.User = cfn.user
 	config.Passwd = cfn.password


### PR DESCRIPTION
I used schemalex-deploy with the following `~/.my.cnf` file.

```
[client]
host=example.com
port=3306
user=foo
password=bar
database=sample_db
```

However, schemalex-deploy still tried to connect to `127.0.0.1`. 

In `config.FormatDSN()`, `config.Addr` is ignored if `config.Net` is not set.
https://github.com/go-sql-driver/mysql/blob/bcc459a906419e2890a50fc2c99ea6dd927a88f2/dsn.go#L181-L189

I have set `config.Net = tcp`, which should solve this problem.