### PR TITLE
simplify normalizing

### DIFF
--- a/model/index.go
+++ b/model/index.go
@@ -97,11 +97,7 @@ func (stmt *Index) ID() string {
 	return fmt.Sprintf("%s#%x", name, h.Sum(nil))
 }
 
-func (stmt *Index) Normalize() (*Index, bool) {
-	return stmt, false
-}
-
-func (stmt *Index) Clone() *Index {
+func (stmt *Index) Normalize() *Index {
 	newindex := *stmt
 	return &newindex
 }

--- a/model/table_column_test.go
+++ b/model/table_column_test.go
@@ -203,7 +203,7 @@ func TestTableColumnNormalize(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("from %q to %q", tc.beforeStr, tc.afterStr), func(t *testing.T) {
-			norm, _ := tc.before.Normalize()
+			norm := tc.before.Normalize()
 			if diff := cmp.Diff(tc.after, norm); diff != "" {
 				t.Errorf("mismatch (-want/+got)\n%s", diff)
 			}

--- a/parser.go
+++ b/parser.go
@@ -282,7 +282,7 @@ func (p *Parser) parseCreateTable(ctx *parseCtx) (*model.Table, error) {
 		return nil, err
 	}
 
-	table, _ = table.Normalize()
+	table = table.Normalize()
 	return table, nil
 }
 


### PR DESCRIPTION
`Normalize()` methods check whether tables or columns are already normalized.
However, normalizing is not so heavy operation.
Skipping this check makes the methods more simple.