### PR TITLE
migrate to the std error package

### DIFF
--- a/diff/diff.go
+++ b/diff/diff.go
@@ -12,7 +12,6 @@ import (
 	mapset "github.com/deckarep/golang-set"
 	"github.com/shogo82148/schemalex-deploy"
 	"github.com/shogo82148/schemalex-deploy/format"
-	"github.com/shogo82148/schemalex-deploy/internal/errors"
 	"github.com/shogo82148/schemalex-deploy/internal/util"
 	"github.com/shogo82148/schemalex-deploy/model"
 )
@@ -121,12 +120,12 @@ func Strings(dst io.Writer, from, to string, options ...Option) error {
 
 	stmts1, err := p.ParseString(from)
 	if err != nil {
-		return errors.Wrapf(err, `failed to parse "from" %s`, from)
+		return fmt.Errorf(`failed to parse "from" %s: %w`, from, err)
 	}
 
 	stmts2, err := p.ParseString(to)
 	if err != nil {
-		return errors.Wrapf(err, `failed to parse "to" %s`, to)
+		return fmt.Errorf(`failed to parse "to" %s: %w`, to, err)
 	}
 
 	return Statements(dst, stmts1, stmts2, options...)

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/deckarep/golang-set v1.7.1
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/google/go-cmp v0.5.6
-	github.com/pkg/errors v0.9.1
 	golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e // indirect
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b
 )

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfC
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e h1:WUoyKPm6nCo1BnNUvPGnFG3T5DUVem42yDJZZ4CNxMA=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -1,24 +1,20 @@
 package errors
 
 import (
-	daverr "github.com/pkg/errors"
+	"errors"
 )
 
 type ignorableErr struct {
-	err error
+	error
 }
 
 type ignorabler interface {
 	Ignorable() bool
 }
 
-type causer interface {
-	Cause() error
-}
-
 func (e ignorableErr) Error() string {
-	if e.err != nil {
-		return e.err.Error() + " (ignorable)"
+	if e.error != nil {
+		return e.error.Error() + " (ignorable)"
 	}
 	return "(ignorable)"
 }
@@ -28,36 +24,16 @@ func (e ignorableErr) Ignorable() bool {
 }
 
 func Ignorable(err error) error {
-	return ignorableErr{err: err}
+	return ignorableErr{error: err}
 }
 
 func IsIgnorable(err error) bool {
-	for err != nil {
-		if ignore, ok := err.(ignorabler); ok {
-			return ignore.Ignorable()
-		}
-
-		if cerr, ok := err.(causer); ok {
-			err = cerr.Cause()
-		} else {
-			return false
-		}
+	if err == nil {
+		return false
+	}
+	var ignore ignorabler
+	if errors.As(err, &ignore) {
+		return ignore.Ignorable()
 	}
 	return false
-}
-
-func New(s string) error {
-	return daverr.New(s)
-}
-
-func Errorf(s string, args ...interface{}) error {
-	return daverr.Errorf(s, args...)
-}
-
-func Wrap(err error, s string) error {
-	return daverr.Wrap(err, s)
-}
-
-func Wrapf(err error, s string, args ...interface{}) error {
-	return daverr.Wrapf(err, s, args...)
 }

--- a/lexer.go
+++ b/lexer.go
@@ -2,10 +2,9 @@ package schemalex
 
 import (
 	"bytes"
+	"errors"
 	"strings"
 	"unicode/utf8"
-
-	"github.com/shogo82148/schemalex-deploy/internal/errors"
 )
 
 const eof = rune(0)


### PR DESCRIPTION
Go officially supports `Unwrap()` methods from Go 1.13.
