### PR TITLE
propose `-import` option

### DIFF
--- a/cmd/schemalex-deploy/config.go
+++ b/cmd/schemalex-deploy/config.go
@@ -12,6 +12,16 @@ import (
 	"github.com/shogo82148/schemalex-deploy/mycnf"
 )
 
+// ExecMode execute mode
+type ExecMode string
+
+const (
+	// ExecModeDeploy deploy mode
+	ExecModeDeploy ExecMode = "deploy"
+	// ExecModeImport import mode
+	ExecModeImport ExecMode = "import"
+)
+
 type config struct {
 	version     bool
 	socket      string
@@ -23,6 +33,7 @@ type config struct {
 	schema      []byte
 	autoApprove bool
 	dryRun      bool
+	mode        ExecMode
 }
 
 func loadConfig() (*config, error) {
@@ -33,6 +44,7 @@ func loadConfig() (*config, error) {
 	var port int
 	var approve bool
 	var dryRun bool
+	var runImport bool
 
 	flag.Usage = func() {
 		// TODO: fill the usage
@@ -55,6 +67,7 @@ schemalex -version
 	// for schemalex-deploy
 	flag.BoolVar(&approve, "auto-approve", false, "skips interactive approval of plan before deploying")
 	flag.BoolVar(&dryRun, "dry-run", false, "outputs the schema difference, and then exit the program")
+	flag.BoolVar(&runImport, "import", false, "imports existing table schemas from running database")
 	flag.Parse()
 
 	if version {
@@ -64,6 +77,12 @@ schemalex -version
 
 	cfn.autoApprove = approve
 	cfn.dryRun = dryRun
+
+	// choose execute mode
+	cfn.mode = ExecModeDeploy
+	if runImport {
+		cfn.mode = ExecModeImport
+	}
 
 	// load configure from files
 	cnfFile, err := mycnf.LoadDefault("")

--- a/deploy/deploy_test.go
+++ b/deploy/deploy_test.go
@@ -122,3 +122,71 @@ func showColumns(ctx context.Context, db *sql.DB, table string) ([]*column, erro
 	}
 	return columns, nil
 }
+
+func TestImport(t *testing.T) {
+	database.SkipIfNoTestDatabase(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	rawDB, cleanup := database.SetupTestDB()
+	defer cleanup()
+	db := &DB{
+		db: rawDB,
+	}
+
+	t.Run("no table is detected", func(t *testing.T) {
+		sqlText, err := db.LoadSchema(ctx)
+		if err != nil {
+			t.Fatalf("failed to empty import: %v", err)
+		}
+		if sqlText != "" {
+			t.Errorf("want empty string \"\", but not: %q", sqlText)
+		}
+	})
+
+	t.Run("after create table", func(t *testing.T) {
+		tb1 := `CREATE TABLE hoge (
+			id INTEGER NOT NULL AUTO_INCREMENT,
+			c VARCHAR (20) NOT NULL DEFAULT "hoge",
+			PRIMARY KEY (id)
+		);
+`
+		if _, err := db.db.ExecContext(ctx, tb1); err != nil {
+			t.Fatalf("failed to create `hoge` table: %v", err)
+		}
+
+		tb2 := `CREATE TABLE fuga (
+			id INTEGER NOT NULL AUTO_INCREMENT,
+			PRIMARY KEY (id)
+		);
+`
+		if _, err := db.db.ExecContext(ctx, tb2); err != nil {
+			t.Fatalf("failed to create `fuga` table: %v", err)
+		}
+
+		sqlText, err := db.LoadSchema(ctx)
+		if err != nil {
+			t.Fatalf("failed to load schema: %v", err)
+		}
+
+		if err := db.Import(ctx, sqlText); err != nil {
+			t.Fatalf("failed to import: %v", err)
+		}
+
+		latest, err := getLatestVersion(ctx, db.db)
+		if err != nil {
+			t.Fatalf("failed to get the latest version: %v", err)
+		}
+		if latest.ID == 0 {
+			t.Fatal("want schemalex revision exists, but not")
+		}
+
+		plan, err := db.Plan(ctx, tb1+tb2)
+		if err != nil {
+			t.Fatalf("failed to plan: %v", err)
+		}
+		if len(plan.Stmts) > 0 {
+			t.Errorf("want no diff is detected, but not: %v", plan.Stmts)
+		}
+	})
+}


### PR DESCRIPTION
Currently, `schemalex-deploy` assumes that you have previously migrated with `schemalex` or `schemalex-deploy`. Therefore, it is not possible to use `schemalex-deploy` later on a database that is already running.

I would like to use `schemalex-deploy` for migration of already running databases. I propose a new `-import` option; get the existing table schemas from the database and import them.