### PR TITLE
Fix setup condition in import mode

### DIFF
--- a/cmd/schemalex-deploy/config.go
+++ b/cmd/schemalex-deploy/config.go
@@ -157,15 +157,18 @@ schemalex -version
 		cfn.database = database
 	}
 
-	if flag.NArg() == 0 {
-		flag.Usage()
-		return nil, errors.New("schema file is required")
+	// deploy mode: load schema file
+	if cfn.mode == ExecModeDeploy {
+		if flag.NArg() == 0 {
+			flag.Usage()
+			return nil, errors.New("schema file is required")
+		}
+		schema, err := os.ReadFile(flag.Arg(0))
+		if err != nil {
+			return nil, err
+		}
+		cfn.schema = schema
 	}
-	schema, err := os.ReadFile(flag.Arg(0))
-	if err != nil {
-		return nil, err
-	}
-	cfn.schema = schema
 
 	return &cfn, nil
 }


### PR DESCRIPTION
I added import mode in #60 , but there was a bug in that impl. Currently, schemalex-deploy requires a schema file in deploy mode, but also requires a schema file in import mode, even though it should not.

```
$ schemalex-deploy -import -database sample
schemalex-deploy version (devel) (d49bf2aef1c67c81662250efd30fc970e371862d at 2022-09-05T09:25:09Z, modified), built with go1.19.1 for darwin/amd64

schemalex -version
2022/09/07 13:02:04 schema file is required
```

To resolve this issue, I have improved the flow that loads the schema file.