### PR TITLE
migrate to the environment files of GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,8 @@ jobs:
               'include': includes
           }
           output = json.dumps(matrix, separators=(',', ':'))
-          print('::set-output name=matrix::{0}'.format(output))
+          with open(os.environ['GITHUB_OUTPUT'], 'a', encoding='utf-8') as f:
+            f.write('matrix={0}\n'.format(output))
         shell: python
 
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
         id: set-matrix
         run: |
           import json
+          import os
           mysql = [
               '8.0',
               '5.7',


### PR DESCRIPTION
> GitHub Actions: Deprecating save-state and set-output commands
> https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/