### PR TITLE
fix parsing spatial index.

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -1169,9 +1169,9 @@ func (p *Parser) parseColumnIndexSpatialKey(ctx *parseCtx, index *model.Index) e
 		return newParseError(ctx, t, "expected SPATIAL")
 	}
 
-	// optional INDEX
+	// optional INDEX or KEY
 	ctx.skipWhiteSpaces()
-	if t := ctx.peek(); t.Type == INDEX {
+	if t := ctx.peek(); t.Type == INDEX || t.Type == KEY {
 		ctx.advance()
 	}
 


### PR DESCRIPTION
```sql
CREATE TABLE `fuga` (
`id` INTEGER NOT NULL AUTO_INCREMENT,
`point` POINT SRID 4326 NOT NULL,
SPATIAL KEY `idx_point` (`point`),
PRIMARY KEY (`id`)
);
```

It generates unexpected error: got an error: parse error: expected LPAREN while parsing index column: KEY at line 4 column 8.