### PR TITLE
Resolved the issue of being unable to retrieve port numbers and usernames from configuration files

### DIFF
--- a/cmd/schemalex-deploy/config.go
+++ b/cmd/schemalex-deploy/config.go
@@ -105,7 +105,7 @@ func loadConfig() (*config, error) {
 			cfn.host = v
 		}
 		if v, ok := client["port"]; ok {
-			if i, err := strconv.Atoi(v); err != nil {
+			if i, err := strconv.Atoi(v); err == nil { // if NO error
 				cfn.port = i
 			}
 		}
@@ -137,13 +137,13 @@ func loadConfig() (*config, error) {
 		}
 	} else {
 		if cfn.user == "" {
-			if u, err := user.Current(); err != nil {
+			if u, err := user.Current(); err == nil { // if NO error
 				cfn.user = u.Username
 			}
 		}
 	}
 	if v := os.Getenv("MYSQL_TCP_PORT"); v != "" {
-		if i, err := strconv.Atoi(v); err != nil {
+		if i, err := strconv.Atoi(v); err == nil { // if NO error
 			cfn.port = i
 		}
 	}
@@ -154,7 +154,7 @@ func loadConfig() (*config, error) {
 	if host != "" {
 		cfn.host = host
 	}
-	if port != 0 {
+	if port != 3306 {
 		cfn.port = port
 	}
 	if username != "" {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in configuration settings: Now ensures that the port number is set correctly only if the conversion from string to integer is successful. A default port of 3306 is used if no specific port is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->