### PR TITLE
bump Go 1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/shogo82148/schemalex-deploy
 
-go 1.22.2
+go 1.23.0
 
 require (
 	github.com/go-sql-driver/mysql v1.8.1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the Go version from 1.22.2 to 1.23.0 for improved performance and access to new features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->