### PR TITLE
fix: DEPRECATED:  snapshot.name_template  should not be used anymore

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,5 @@
 # Make sure to check the documentation at http://goreleaser.com
+version: 2
 before:
   hooks:
     - go mod download
@@ -39,7 +40,7 @@ archives:
 checksum:
   name_template: "checksums.txt"
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  version_template: "{{ .Tag }}-next"
 
 nfpms:
   - id: package-amd64


### PR DESCRIPTION
see https://goreleaser.com/deprecations/#snapshotname_template

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated configuration format with a new version key.
- **Changes**
	- Modified snapshot versioning handling.
- **Chores**
	- Consolidated output file naming for builds.
	- Ensured consistency in build and packaging definitions across architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->