### PR TITLE
bump Go 1.24

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/shogo82148/schemalex-deploy
 
-go 1.23.0
+go 1.24.1
 
 require (
 	github.com/go-sql-driver/mysql v1.9.1

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"database/sql"
 	"encoding/hex"
-	"fmt"
 	"net"
 	"os"
 	"sort"
@@ -57,7 +56,7 @@ func SetupTestDB() (*sql.DB, func()) {
 		panic(err)
 	}
 	dbName := "schemalex_test_" + hex.EncodeToString(b[:])
-	_, err = db1.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE "+util.Backquote(dbName)))
+	_, err = db1.ExecContext(ctx, "CREATE DATABASE "+util.Backquote(dbName))
 	if err != nil {
 		panic(err)
 	}
@@ -74,7 +73,7 @@ func SetupTestDB() (*sql.DB, func()) {
 		defer cancel()
 
 		// clean up
-		db2.ExecContext(ctx, fmt.Sprintf("DROP DATABASE "+util.Backquote(dbName)))
+		db2.ExecContext(ctx, "DROP DATABASE "+util.Backquote(dbName))
 		db2.Close()
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Upgraded the underlying runtime to Go version 1.24.1, delivering enhanced performance, improved stability, and a more reliable experience for our users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->