### PR TITLE
support encrypted connections with the ssl-mode option

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,7 @@ Changes
 ## [unreleased]
 
 - support removing indexes without their names [#68](https://github.com/shogo82148/schemalex-deploy/pull/68)
+- support encrypted connections with the `-ssl-mode` and `-ssl-ca` options [#220](https://github.com/shogo82148/schemalex-deploy/pull/220)
 
 ## [v0.0.7] - 2022-09-08
 

--- a/README.md
+++ b/README.md
@@ -88,10 +88,42 @@ Enter a value: yes
 -user             username
 -password         password
 -database         the database name
+-ssl-mode         the security state of the connection to the database
+                  (DISABLED, PREFERRED, REQUIRED, VERIFY_CA or VERIFY_IDENTITY.
+                  default: PREFERRED, or VERIFY_CA if -ssl-ca is specified)
+-ssl-ca           the path of the file that contains the CA certificate
+                  (used by VERIFY_CA and VERIFY_IDENTITY)
 -version          show the version
 -auto-approve     skips interactive approval of plan before deploying
 -dry-run          outputs the schema difference, and then exit the program
 -import           imports existing table schemas from running database
+```
+
+## ENCRYPTED CONNECTIONS
+
+`-ssl-mode` is compatible with [the option of the same name of the mysql(1)](https://dev.mysql.com/doc/refman/8.0/en/connection-options.html#option_general_ssl-mode).
+The default is `PREFERRED`: schemalex-deploy uses an encrypted connection if the server supports it,
+and falls back to an unencrypted connection otherwise.
+Note that `PREFERRED` and `REQUIRED` don't verify the server certificate.
+
+`-ssl-mode` and `-ssl-ca` can also be specified in the `[client]` group of my.cnf.
+
+Amazon Aurora MySQL 8.4 and later enable `require_secure_transport` by default,
+so unencrypted connections are rejected with the following error:
+
+```plain
+Error 3159 (HY000): Connections using insecure transport are prohibited while --require_secure_transport=ON.
+```
+
+The default `PREFERRED` is enough to connect to them.
+To verify the server certificate, download [the CA certificate bundle of Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/UsingWithRDS.SSL.html)
+and pass it to `-ssl-ca`. It is not included in the system certificate store.
+
+```plain
+$ curl -O https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem
+$ schemalex-deploy -host my-cluster.cluster-xxxxxxxx.ap-northeast-1.rds.amazonaws.com \
+    -user admin -password password -database gotest \
+    -ssl-mode VERIFY_IDENTITY -ssl-ca global-bundle.pem schema.sql
 ```
 
 ## SEE ALSO

--- a/cmd/schemalex-deploy/config.go
+++ b/cmd/schemalex-deploy/config.go
@@ -8,6 +8,7 @@ import (
 	"os/user"
 	"runtime"
 	"strconv"
+	"strings"
 
 	"github.com/shogo82148/schemalex-deploy/mycnf"
 )
@@ -30,6 +31,8 @@ type config struct {
 	Password    string
 	Database    string
 	Port        int
+	SSLMode     SSLMode
+	SSLCA       string
 	Schema      []byte
 	AutoApprove bool
 	DryRun      bool
@@ -39,12 +42,24 @@ type config struct {
 // for testing
 var loadDefault = mycnf.LoadDefault
 
+// lookupOption looks up the option named name in the group.
+// mysql(1) treats dashes and underscores in option names interchangeably.
+// https://dev.mysql.com/doc/refman/8.0/en/option-files.html
+func lookupOption(group map[string]string, name string) (string, bool) {
+	if v, ok := group[name]; ok {
+		return v, true
+	}
+	v, ok := group[strings.ReplaceAll(name, "-", "_")]
+	return v, ok
+}
+
 func loadConfig(args []string) (*config, error) {
 	var cfn config
 	var version bool
 	var socket string
 	var host, username, password, database string
 	var port int
+	var sslMode, sslCA string
 	var approve bool
 	var dryRun bool
 	var runImport bool
@@ -60,6 +75,11 @@ func loadConfig(args []string) (*config, error) {
 -user             username
 -password         password
 -database         the database name
+-ssl-mode         the security state of the connection to the database
+                  (DISABLED, PREFERRED, REQUIRED, VERIFY_CA or VERIFY_IDENTITY.
+                  default: PREFERRED, or VERIFY_CA if -ssl-ca is specified)
+-ssl-ca           the path of the file that contains the CA certificate
+                  (used by VERIFY_CA and VERIFY_IDENTITY)
 -version          show the version
 -auto-approve     skips interactive approval of plan before deploying
 -dry-run          outputs the schema difference, and then exit the program
@@ -75,6 +95,8 @@ func loadConfig(args []string) (*config, error) {
 	flagSet.StringVar(&username, "user", "", "username")
 	flagSet.StringVar(&password, "password", "", "password")
 	flagSet.StringVar(&database, "database", "", "the database name")
+	flagSet.StringVar(&sslMode, "ssl-mode", "", "the security state of the connection to the database")
+	flagSet.StringVar(&sslCA, "ssl-ca", "", "the path of the file that contains the CA certificate")
 	flagSet.BoolVar(&version, "version", false, "show the version")
 
 	// for schemalex-deploy
@@ -126,6 +148,16 @@ func loadConfig(args []string) (*config, error) {
 		if v, ok := client["database"]; ok {
 			cfn.Database = v
 		}
+		if v, ok := lookupOption(client, "ssl-mode"); ok {
+			mode, err := parseSSLMode(v)
+			if err != nil {
+				return nil, err
+			}
+			cfn.SSLMode = mode
+		}
+		if v, ok := lookupOption(client, "ssl-ca"); ok {
+			cfn.SSLCA = v
+		}
 	}
 
 	// load configure from the environment values
@@ -173,6 +205,26 @@ func loadConfig(args []string) (*config, error) {
 	}
 	if database != "" {
 		cfn.Database = database
+	}
+	if sslMode != "" {
+		mode, err := parseSSLMode(sslMode)
+		if err != nil {
+			return nil, err
+		}
+		cfn.SSLMode = mode
+	}
+	if sslCA != "" {
+		cfn.SSLCA = sslCA
+	}
+
+	// if the ssl-mode is not explicitly set, use of the ssl-ca implies VERIFY_CA.
+	// https://dev.mysql.com/doc/refman/8.0/en/connection-options.html#option_general_ssl-ca
+	if cfn.SSLMode == "" {
+		if cfn.SSLCA != "" {
+			cfn.SSLMode = SSLModeVerifyCA
+		} else {
+			cfn.SSLMode = SSLModePreferred
+		}
 	}
 
 	// deploy mode: load schema file

--- a/cmd/schemalex-deploy/config_test.go
+++ b/cmd/schemalex-deploy/config_test.go
@@ -45,6 +45,7 @@ func TestLoadConfig(t *testing.T) {
 				User:     "shogo",
 				Password: "secret",
 				Port:     3306,
+				SSLMode:  SSLModePreferred,
 				Schema:   []byte{},
 				Mode:     ExecModeDeploy,
 			},
@@ -63,6 +64,7 @@ func TestLoadConfig(t *testing.T) {
 				User:     "shogo",
 				Password: "environment",
 				Port:     3306,
+				SSLMode:  SSLModePreferred,
 				Schema:   []byte{},
 				Mode:     ExecModeDeploy,
 			},
@@ -80,6 +82,7 @@ func TestLoadConfig(t *testing.T) {
 				User:     "shogo",
 				Password: "password",
 				Port:     3306,
+				SSLMode:  SSLModePreferred,
 				Schema:   []byte{},
 				Mode:     ExecModeDeploy,
 			},
@@ -101,6 +104,7 @@ func TestLoadConfig(t *testing.T) {
 				User:     "chooblarin",
 				Password: "password",
 				Port:     1234,
+				SSLMode:  SSLModePreferred,
 				Schema:   []byte{},
 				Mode:     ExecModeDeploy,
 			},
@@ -120,6 +124,7 @@ func TestLoadConfig(t *testing.T) {
 				User:     "chooblarin",
 				Password: "password",
 				Port:     3456,
+				SSLMode:  SSLModePreferred,
 				Schema:   []byte{},
 				Mode:     ExecModeDeploy,
 			},
@@ -138,8 +143,71 @@ func TestLoadConfig(t *testing.T) {
 				User:     "chooblarin",
 				Password: "password",
 				Port:     2345,
+				SSLMode:  SSLModePreferred,
 				Schema:   []byte{},
 				Mode:     ExecModeDeploy,
+			},
+		},
+
+		// ssl-mode
+		{
+			name: "The ssl-mode specified in the argument takes precedence",
+			args: []string{"schemalex-deploy", "-user", "shogo", "-ssl-mode", "REQUIRED", filepath.Join("testdata", "schema.sql")},
+			cnf: mycnf.MyCnf{
+				"client": map[string]string{
+					"ssl-mode": "DISABLED",
+				},
+			},
+			want: &config{
+				User:    "shogo",
+				Port:    3306,
+				SSLMode: SSLModeRequired,
+				Schema:  []byte{},
+				Mode:    ExecModeDeploy,
+			},
+		},
+		{
+			name: "The ssl-mode specified in the configure file takes precedence",
+			args: []string{"schemalex-deploy", "-user", "shogo", filepath.Join("testdata", "schema.sql")},
+			cnf: mycnf.MyCnf{
+				"client": map[string]string{
+					"ssl_mode": "verify_identity",
+					"ssl_ca":   "/path/to/ca.pem",
+				},
+			},
+			want: &config{
+				User:    "shogo",
+				Port:    3306,
+				SSLMode: SSLModeVerifyIdentity,
+				SSLCA:   "/path/to/ca.pem",
+				Schema:  []byte{},
+				Mode:    ExecModeDeploy,
+			},
+		},
+		{
+			name: "The ssl-ca implies VERIFY_CA",
+			args: []string{"schemalex-deploy", "-user", "shogo", "-ssl-ca", "/path/to/ca.pem", filepath.Join("testdata", "schema.sql")},
+			cnf:  mycnf.MyCnf{},
+			want: &config{
+				User:    "shogo",
+				Port:    3306,
+				SSLMode: SSLModeVerifyCA,
+				SSLCA:   "/path/to/ca.pem",
+				Schema:  []byte{},
+				Mode:    ExecModeDeploy,
+			},
+		},
+		{
+			name: "The ssl-ca doesn't imply VERIFY_CA if the ssl-mode is explicitly set",
+			args: []string{"schemalex-deploy", "-user", "shogo", "-ssl-ca", "/path/to/ca.pem", "-ssl-mode", "PREFERRED", filepath.Join("testdata", "schema.sql")},
+			cnf:  mycnf.MyCnf{},
+			want: &config{
+				User:    "shogo",
+				Port:    3306,
+				SSLMode: SSLModePreferred,
+				SSLCA:   "/path/to/ca.pem",
+				Schema:  []byte{},
+				Mode:    ExecModeDeploy,
 			},
 		},
 	}
@@ -162,6 +230,47 @@ func TestLoadConfig(t *testing.T) {
 			}
 			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("unexpected config: (-want/+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestLoadConfig_error(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		cnf  mycnf.MyCnf
+	}{
+		{
+			name: "unknown ssl-mode in the argument",
+			args: []string{"schemalex-deploy", "-ssl-mode", "ENABLED", filepath.Join("testdata", "schema.sql")},
+			cnf:  mycnf.MyCnf{},
+		},
+		{
+			name: "unknown ssl-mode in the configure file",
+			args: []string{"schemalex-deploy", filepath.Join("testdata", "schema.sql")},
+			cnf: mycnf.MyCnf{
+				"client": map[string]string{
+					"ssl-mode": "ENABLED",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			orig := loadDefault
+			loadDefault = func(extraFile string) (mycnf.MyCnf, error) {
+				return tt.cnf, nil
+			}
+			defer func() { loadDefault = orig }()
+			t.Setenv("MYSQL_UNIX_PORT", "")
+			t.Setenv("MYSQL_TCP_PORT", "")
+			t.Setenv("MYSQL_HOST", "")
+			t.Setenv("MYSQL_PWD", "")
+
+			if _, err := loadConfig(tt.args); err == nil {
+				t.Error("loadConfig doesn't return an error")
 			}
 		})
 	}

--- a/cmd/schemalex-deploy/schemalex-deploy.go
+++ b/cmd/schemalex-deploy/schemalex-deploy.go
@@ -61,6 +61,9 @@ func _main() error {
 		// kamipo TRADITIONAL http://www.songmu.jp/riji/entry/2015-07-08-kamipo-traditional.html
 		"sql_mode": "'TRADITIONAL,NO_AUTO_VALUE_ON_ZERO,ONLY_FULL_GROUP_BY'",
 	}
+	if err := cfn.configureTLS(config); err != nil {
+		return err
+	}
 
 	db, err := deploy.Open("mysql", config.FormatDSN())
 	if err != nil {

--- a/cmd/schemalex-deploy/ssl.go
+++ b/cmd/schemalex-deploy/ssl.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/go-sql-driver/mysql"
+)
+
+// SSLMode is the desired security state of the connection to the server.
+// It is compatible with the --ssl-mode option of the mysql(1).
+// https://dev.mysql.com/doc/refman/8.0/en/connection-options.html#option_general_ssl-mode
+type SSLMode string
+
+const (
+	// SSLModeDisabled establishes an unencrypted connection.
+	SSLModeDisabled SSLMode = "DISABLED"
+
+	// SSLModePreferred establishes an encrypted connection if the server supports it,
+	// and falls back to an unencrypted connection otherwise.
+	// It is the default, and it doesn't verify the server certificate.
+	SSLModePreferred SSLMode = "PREFERRED"
+
+	// SSLModeRequired establishes an encrypted connection, and fails if it is not available.
+	// It doesn't verify the server certificate.
+	SSLModeRequired SSLMode = "REQUIRED"
+
+	// SSLModeVerifyCA establishes an encrypted connection,
+	// and verifies the server certificate against the CA certificates.
+	SSLModeVerifyCA SSLMode = "VERIFY_CA"
+
+	// SSLModeVerifyIdentity establishes an encrypted connection,
+	// and verifies the server certificate against the CA certificates
+	// in addition to the host name of the server.
+	SSLModeVerifyIdentity SSLMode = "VERIFY_IDENTITY"
+)
+
+// parseSSLMode parses the value of the -ssl-mode option.
+func parseSSLMode(s string) (SSLMode, error) {
+	mode := SSLMode(strings.ToUpper(s))
+	switch mode {
+	case SSLModeDisabled, SSLModePreferred, SSLModeRequired, SSLModeVerifyCA, SSLModeVerifyIdentity:
+		return mode, nil
+	}
+	return "", fmt.Errorf("unknown ssl-mode: %q", s)
+}
+
+// tlsConfigName is the name of the TLS configuration registered to the mysql driver.
+const tlsConfigName = "schemalex-deploy"
+
+// configureTLS configures the TLS settings of dsn.
+//
+// The mysql driver serializes only [mysql.Config.TLSConfig] into the DSN,
+// so the configuration needs to be registered by [mysql.RegisterTLSConfig]
+// instead of setting [mysql.Config.TLS] directly.
+func (cfn *config) configureTLS(dsn *mysql.Config) error {
+	switch cfn.SSLMode {
+	case SSLModeDisabled:
+		dsn.TLSConfig = "false"
+	case SSLModePreferred:
+		// use TLS if the server supports it, and fall back to an unencrypted connection otherwise.
+		dsn.TLSConfig = "preferred"
+	case SSLModeRequired:
+		// require TLS, but don't verify the server certificate.
+		dsn.TLSConfig = "skip-verify"
+	case SSLModeVerifyCA, SSLModeVerifyIdentity:
+		tlsConfig, err := cfn.tlsConfig()
+		if err != nil {
+			return err
+		}
+		if err := mysql.RegisterTLSConfig(tlsConfigName, tlsConfig); err != nil {
+			return fmt.Errorf("failed to register the tls configure: %w", err)
+		}
+		dsn.TLSConfig = tlsConfigName
+	default:
+		return fmt.Errorf("unknown ssl-mode: %q", string(cfn.SSLMode))
+	}
+	return nil
+}
+
+// tlsConfig builds the TLS configuration for VERIFY_CA and VERIFY_IDENTITY.
+func (cfn *config) tlsConfig() (*tls.Config, error) {
+	// if no CA certificate is given, the system certificate pool is used.
+	var rootCAs *x509.CertPool
+	if cfn.SSLCA != "" {
+		data, err := os.ReadFile(cfn.SSLCA)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read the ca certificate: %w", err)
+		}
+		rootCAs = x509.NewCertPool()
+		if !rootCAs.AppendCertsFromPEM(data) {
+			return nil, fmt.Errorf("failed to parse the ca certificate %q", cfn.SSLCA)
+		}
+	}
+
+	if cfn.SSLMode == SSLModeVerifyIdentity {
+		if cfn.Socket != "" {
+			return nil, errors.New("ssl-mode VERIFY_IDENTITY is not available with the unix domain socket")
+		}
+		serverName := cfn.Host
+		if serverName == "" {
+			// the connection goes to the localhost if the host is not specified.
+			serverName = "localhost"
+		}
+		return &tls.Config{
+			RootCAs:    rootCAs,
+			ServerName: serverName,
+			MinVersion: tls.VersionTLS12,
+		}, nil
+	}
+
+	// VERIFY_CA verifies the certificate chain, but doesn't verify the host name.
+	// crypto/tls has no such option, so we verify the chain by ourselves.
+	return &tls.Config{
+		RootCAs:               rootCAs,
+		InsecureSkipVerify:    true, // the chain is verified in verifyCA.
+		VerifyPeerCertificate: verifyCA(rootCAs),
+		MinVersion:            tls.VersionTLS12,
+	}, nil
+}
+
+// verifyCA returns a function that verifies the certificate chain without verifying the host name.
+func verifyCA(rootCAs *x509.CertPool) func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+	return func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
+		if len(rawCerts) == 0 {
+			return errors.New("the server sent no certificate")
+		}
+		certs := make([]*x509.Certificate, 0, len(rawCerts))
+		for _, rawCert := range rawCerts {
+			cert, err := x509.ParseCertificate(rawCert)
+			if err != nil {
+				return fmt.Errorf("failed to parse the server certificate: %w", err)
+			}
+			certs = append(certs, cert)
+		}
+
+		intermediates := x509.NewCertPool()
+		for _, cert := range certs[1:] {
+			intermediates.AddCert(cert)
+		}
+		_, err := certs[0].Verify(x509.VerifyOptions{
+			Roots:         rootCAs,
+			Intermediates: intermediates,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to verify the server certificate: %w", err)
+		}
+		return nil
+	}
+}

--- a/cmd/schemalex-deploy/ssl.go
+++ b/cmd/schemalex-deploy/ssl.go
@@ -52,6 +52,38 @@ func parseSSLMode(s string) (SSLMode, error) {
 // tlsConfigName is the name of the TLS configuration registered to the mysql driver.
 const tlsConfigName = "schemalex-deploy"
 
+// tlsConfigNameInsecure is the name of the TLS configuration that doesn't verify the server certificate.
+const tlsConfigNameInsecure = "schemalex-deploy-insecure"
+
+// insecureTLSConfig returns the TLS configuration for PREFERRED and REQUIRED.
+// They don't verify the server certificate.
+func insecureTLSConfig() *tls.Config {
+	return &tls.Config{
+		InsecureSkipVerify: true, // PREFERRED and REQUIRED don't verify the server certificate.
+		MinVersion:         tls.VersionTLS12,
+		CipherSuites:       cipherSuites(),
+	}
+}
+
+// cipherSuites returns the default cipher suites of crypto/tls,
+// plus the ones that use the RSA key exchange.
+//
+// Go 1.22 and later exclude the RSA key exchange from the default cipher suites,
+// but MySQL 5.7 and MariaDB 10.1 can't use the elliptic curve key exchange,
+// so we need them to keep connecting to those servers.
+func cipherSuites() []uint16 {
+	suites := make([]uint16, 0, len(tls.CipherSuites())+4)
+	for _, suite := range tls.CipherSuites() {
+		suites = append(suites, suite.ID)
+	}
+	return append(suites,
+		tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+		tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+	)
+}
+
 // configureTLS configures the TLS settings of dsn.
 //
 // The mysql driver serializes only [mysql.Config.TLSConfig] into the DSN,
@@ -63,10 +95,17 @@ func (cfn *config) configureTLS(dsn *mysql.Config) error {
 		dsn.TLSConfig = "false"
 	case SSLModePreferred:
 		// use TLS if the server supports it, and fall back to an unencrypted connection otherwise.
-		dsn.TLSConfig = "preferred"
+		if err := mysql.RegisterTLSConfig(tlsConfigNameInsecure, insecureTLSConfig()); err != nil {
+			return fmt.Errorf("failed to register the tls configure: %w", err)
+		}
+		dsn.TLSConfig = tlsConfigNameInsecure
+		dsn.AllowFallbackToPlaintext = true
 	case SSLModeRequired:
 		// require TLS, but don't verify the server certificate.
-		dsn.TLSConfig = "skip-verify"
+		if err := mysql.RegisterTLSConfig(tlsConfigNameInsecure, insecureTLSConfig()); err != nil {
+			return fmt.Errorf("failed to register the tls configure: %w", err)
+		}
+		dsn.TLSConfig = tlsConfigNameInsecure
 	case SSLModeVerifyCA, SSLModeVerifyIdentity:
 		tlsConfig, err := cfn.tlsConfig()
 		if err != nil {
@@ -107,9 +146,10 @@ func (cfn *config) tlsConfig() (*tls.Config, error) {
 			serverName = "localhost"
 		}
 		return &tls.Config{
-			RootCAs:    rootCAs,
-			ServerName: serverName,
-			MinVersion: tls.VersionTLS12,
+			RootCAs:      rootCAs,
+			ServerName:   serverName,
+			MinVersion:   tls.VersionTLS12,
+			CipherSuites: cipherSuites(),
 		}, nil
 	}
 
@@ -120,6 +160,7 @@ func (cfn *config) tlsConfig() (*tls.Config, error) {
 		InsecureSkipVerify:    true, // the chain is verified in verifyCA.
 		VerifyPeerCertificate: verifyCA(rootCAs),
 		MinVersion:            tls.VersionTLS12,
+		CipherSuites:          cipherSuites(),
 	}, nil
 }
 

--- a/cmd/schemalex-deploy/ssl_test.go
+++ b/cmd/schemalex-deploy/ssl_test.go
@@ -1,0 +1,254 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/go-sql-driver/mysql"
+)
+
+func TestParseSSLMode(t *testing.T) {
+	tests := []struct {
+		in   string
+		want SSLMode
+	}{
+		{"DISABLED", SSLModeDisabled},
+		{"PREFERRED", SSLModePreferred},
+		{"REQUIRED", SSLModeRequired},
+		{"VERIFY_CA", SSLModeVerifyCA},
+		{"VERIFY_IDENTITY", SSLModeVerifyIdentity},
+		{"verify_ca", SSLModeVerifyCA}, // case insensitive
+	}
+	for _, tt := range tests {
+		got, err := parseSSLMode(tt.in)
+		if err != nil {
+			t.Errorf("parseSSLMode(%q) returns an error: %v", tt.in, err)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("parseSSLMode(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+
+	for _, in := range []string{"", "ENABLED", "verify-ca"} {
+		if _, err := parseSSLMode(in); err == nil {
+			t.Errorf("parseSSLMode(%q) doesn't return an error", in)
+		}
+	}
+}
+
+func TestConfigureTLS(t *testing.T) {
+	tests := []struct {
+		name string
+		cfn  *config
+		want string // the value of the tls parameter in the DSN
+	}{
+		{
+			name: "disabled",
+			cfn:  &config{SSLMode: SSLModeDisabled},
+			want: "false",
+		},
+		{
+			name: "preferred",
+			cfn:  &config{SSLMode: SSLModePreferred},
+			want: "preferred",
+		},
+		{
+			name: "required",
+			cfn:  &config{SSLMode: SSLModeRequired},
+			want: "skip-verify",
+		},
+		{
+			name: "verify_ca",
+			cfn:  &config{SSLMode: SSLModeVerifyCA},
+			want: tlsConfigName,
+		},
+		{
+			name: "verify_identity",
+			cfn:  &config{SSLMode: SSLModeVerifyIdentity, Host: "db.example.com"},
+			want: tlsConfigName,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dsn := mysql.NewConfig()
+			dsn.Net = "tcp"
+			dsn.Addr = "db.example.com:3306"
+			if err := tt.cfn.configureTLS(dsn); err != nil {
+				t.Fatal(err)
+			}
+			if dsn.TLSConfig != tt.want {
+				t.Errorf("unexpected tls configure: got %q, want %q", dsn.TLSConfig, tt.want)
+			}
+
+			// the DSN must keep the TLS settings.
+			// mysql.Config.FormatDSN serializes TLSConfig, but not TLS.
+			parsed, err := mysql.ParseDSN(dsn.FormatDSN())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if parsed.TLSConfig != tt.want {
+				t.Errorf("the tls configure is lost in the DSN: got %q, want %q", parsed.TLSConfig, tt.want)
+			}
+			if tt.cfn.SSLMode != SSLModeDisabled && parsed.TLS == nil {
+				t.Error("the TLS configure is not restored from the DSN")
+			}
+		})
+	}
+}
+
+func TestConfigureTLS_error(t *testing.T) {
+	tests := []struct {
+		name string
+		cfn  *config
+	}{
+		{
+			name: "unknown ssl-mode",
+			cfn:  &config{SSLMode: SSLMode("ENABLED")},
+		},
+		{
+			name: "the ca certificate doesn't exist",
+			cfn:  &config{SSLMode: SSLModeVerifyCA, SSLCA: filepath.Join(t.TempDir(), "not-exist.pem")},
+		},
+		{
+			name: "verify_identity with the unix domain socket",
+			cfn:  &config{SSLMode: SSLModeVerifyIdentity, Socket: "/tmp/mysql.sock"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dsn := mysql.NewConfig()
+			if err := tt.cfn.configureTLS(dsn); err == nil {
+				t.Error("configureTLS doesn't return an error")
+			}
+		})
+	}
+}
+
+func TestConfigureTLS_brokenCACertificate(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ca.pem")
+	if err := os.WriteFile(path, []byte("this is not a certificate"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfn := &config{SSLMode: SSLModeVerifyCA, SSLCA: path}
+	if err := cfn.configureTLS(mysql.NewConfig()); err == nil {
+		t.Error("configureTLS doesn't return an error")
+	}
+}
+
+func TestVerifyCA(t *testing.T) {
+	caCert, caKey := newCertificate(t, "schemalex-deploy test ca", nil, nil)
+	serverCert, _ := newCertificate(t, "db.example.com", caCert, caKey)
+
+	// the certificate is signed by the ca.
+	pool := x509.NewCertPool()
+	pool.AddCert(caCert)
+	if err := verifyCA(pool)([][]byte{serverCert.Raw}, nil); err != nil {
+		t.Errorf("verifyCA rejects the valid certificate: %v", err)
+	}
+
+	// the certificate is not signed by any of the ca.
+	if err := verifyCA(x509.NewCertPool())([][]byte{serverCert.Raw}, nil); err == nil {
+		t.Error("verifyCA accepts the certificate signed by an unknown ca")
+	}
+
+	// the host name is not verified.
+	otherCert, _ := newCertificate(t, "another.example.com", caCert, caKey)
+	if err := verifyCA(pool)([][]byte{otherCert.Raw}, nil); err != nil {
+		t.Errorf("verifyCA verifies the host name: %v", err)
+	}
+
+	// no certificate is sent.
+	if err := verifyCA(pool)(nil, nil); err == nil {
+		t.Error("verifyCA accepts the empty certificate chain")
+	}
+}
+
+func TestTLSConfig_loadCACertificate(t *testing.T) {
+	caCert, _ := newCertificate(t, "schemalex-deploy test ca", nil, nil)
+	path := filepath.Join(t.TempDir(), "ca.pem")
+	data := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caCert.Raw})
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfn := &config{SSLMode: SSLModeVerifyIdentity, Host: "db.example.com", SSLCA: path}
+	tlsConfig, err := cfn.tlsConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tlsConfig.RootCAs == nil {
+		t.Fatal("the ca certificate is not loaded")
+	}
+	if tlsConfig.InsecureSkipVerify {
+		t.Error("VERIFY_IDENTITY must verify the server certificate")
+	}
+	if tlsConfig.ServerName != "db.example.com" {
+		t.Errorf("unexpected server name: got %q, want %q", tlsConfig.ServerName, "db.example.com")
+	}
+}
+
+func TestTLSConfig_defaultServerName(t *testing.T) {
+	// the driver connects to the localhost if the host is not specified,
+	// and crypto/tls fails if the server name is empty.
+	cfn := &config{SSLMode: SSLModeVerifyIdentity}
+	tlsConfig, err := cfn.tlsConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tlsConfig.ServerName != "localhost" {
+		t.Errorf("unexpected server name: got %q, want %q", tlsConfig.ServerName, "localhost")
+	}
+}
+
+// newCertificate creates a certificate for testing.
+// if parent is nil, it creates a self-signed ca certificate.
+func newCertificate(t *testing.T, commonName string, parent *x509.Certificate, parentKey *ecdsa.PrivateKey) (*x509.Certificate, *ecdsa.PrivateKey) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: commonName},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+	if parent == nil {
+		template.IsCA = true
+		template.BasicConstraintsValid = true
+		template.KeyUsage |= x509.KeyUsageCertSign
+		parent = template
+		parentKey = key
+	} else {
+		template.DNSNames = []string{commonName}
+		template.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, parent, &key.PublicKey, parentKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cert, key
+}

--- a/cmd/schemalex-deploy/ssl_test.go
+++ b/cmd/schemalex-deploy/ssl_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
@@ -48,9 +49,10 @@ func TestParseSSLMode(t *testing.T) {
 
 func TestConfigureTLS(t *testing.T) {
 	tests := []struct {
-		name string
-		cfn  *config
-		want string // the value of the tls parameter in the DSN
+		name     string
+		cfn      *config
+		want     string // the value of the tls parameter in the DSN
+		fallback bool   // whether the connection falls back to plaintext
 	}{
 		{
 			name: "disabled",
@@ -58,14 +60,15 @@ func TestConfigureTLS(t *testing.T) {
 			want: "false",
 		},
 		{
-			name: "preferred",
-			cfn:  &config{SSLMode: SSLModePreferred},
-			want: "preferred",
+			name:     "preferred",
+			cfn:      &config{SSLMode: SSLModePreferred},
+			want:     tlsConfigNameInsecure,
+			fallback: true,
 		},
 		{
 			name: "required",
 			cfn:  &config{SSLMode: SSLModeRequired},
-			want: "skip-verify",
+			want: tlsConfigNameInsecure,
 		},
 		{
 			name: "verify_ca",
@@ -103,7 +106,38 @@ func TestConfigureTLS(t *testing.T) {
 			if tt.cfn.SSLMode != SSLModeDisabled && parsed.TLS == nil {
 				t.Error("the TLS configure is not restored from the DSN")
 			}
+			if parsed.AllowFallbackToPlaintext != tt.fallback {
+				t.Errorf("unexpected fallback to plaintext: got %t, want %t", parsed.AllowFallbackToPlaintext, tt.fallback)
+			}
 		})
+	}
+}
+
+func TestCipherSuites(t *testing.T) {
+	// MySQL 5.7 and MariaDB 10.1 can't use the elliptic curve key exchange,
+	// so the cipher suites must contain the ones that use the RSA key exchange.
+	// crypto/tls excludes them from the default since Go 1.22.
+	want := map[uint16]bool{
+		tls.TLS_RSA_WITH_AES_128_GCM_SHA256: false,
+		tls.TLS_RSA_WITH_AES_256_GCM_SHA384: false,
+		tls.TLS_RSA_WITH_AES_128_CBC_SHA:    false,
+		tls.TLS_RSA_WITH_AES_256_CBC_SHA:    false,
+	}
+	suites := cipherSuites()
+	for _, id := range suites {
+		if _, ok := want[id]; ok {
+			want[id] = true
+		}
+	}
+	for id, found := range want {
+		if !found {
+			t.Errorf("the cipher suite %s is not contained", tls.CipherSuiteName(id))
+		}
+	}
+
+	// it must keep the modern cipher suites too.
+	if len(suites) <= len(want) {
+		t.Errorf("the cipher suites are too few: %d", len(suites))
 	}
 }
 


### PR DESCRIPTION
## Motivation

schemalex-deploy always connects in plaintext, and there is no way to enable TLS.

[Amazon Aurora MySQL 8.4](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Security.html) and later enable `require_secure_transport` by default, so schemalex-deploy can no longer connect to them:

```
Error 3159 (HY000): Connections using insecure transport are prohibited while --require_secure_transport=ON.
```

## Changes

Add the `-ssl-mode` and `-ssl-ca` options that are compatible with [the options of the same name of the mysql(1)](https://dev.mysql.com/doc/refman/8.0/en/connection-options.html#option_general_ssl-mode). They can also be specified in the `[client]` group of my.cnf.

| `-ssl-mode` | behavior |
| --- | --- |
| `DISABLED` | connects in plaintext (the behavior before this change) |
| `PREFERRED` | uses TLS if the server supports it, and falls back to plaintext otherwise. **the default** |
| `REQUIRED` | requires TLS, but doesn't verify the server certificate |
| `VERIFY_CA` | verifies the server certificate against the CA certificates |
| `VERIFY_IDENTITY` | verifies the server certificate and the host name of the server |

As well as the mysql(1), use of `-ssl-ca` implies `-ssl-mode=VERIFY_CA` if `-ssl-mode` is not explicitly set.

Note that the CA certificate of Amazon RDS is not included in the system certificate store, so `-ssl-ca` is required to verify the server certificate of Aurora. The README describes how to do it.

### Notes for reviewers

- `mysql.Config.FormatDSN` serializes only `TLSConfig` and drops `TLS`, so the TLS configuration is registered by `mysql.RegisterTLSConfig` instead of setting `mysql.Config.TLS` directly. `TestConfigureTLS` asserts that the settings survive the DSN round trip.
- crypto/tls has no option that verifies the certificate chain without verifying the host name, so `VERIFY_CA` verifies the chain in `VerifyPeerCertificate` by itself. The driver itself doesn't support this mode either: [go-sql-driver/mysql#1742](https://github.com/go-sql-driver/mysql/pull/1742) was closed without merging.
- **MySQL 5.7 needs the cipher suites that use the RSA key exchange.** crypto/tls excludes them from the default since Go 1.22, and MySQL 5.7 can't use the elliptic curve key exchange, so the `PREFERRED` mode fails against MySQL 5.7 with `remote error: tls: handshake failure`. The driver falls back to an unencrypted connection only if the server doesn't advertise TLS, so it doesn't help here. The second commit adds those cipher suites back, which is the same workaround as [Skeema](https://www.skeema.io/blog/2025/02/06/mysql57-golang-ssl/).
- **This changes the default behavior**: connections that used to be unencrypted are now encrypted if the server supports TLS. It follows the default of the mysql(1). `-ssl-mode=DISABLED` restores the previous behavior.

## Tests

`go test ./...` passes. In addition to the unit tests, I confirmed the behavior against real servers running on Docker.

**mysql:8.4 with `--require_secure_transport=ON`** (a server certificate signed by a private CA, with `DNS:localhost` and `IP:127.0.0.1` SANs)

| case | result |
| --- | --- |
| the default (`PREFERRED`) | connected |
| `DISABLED` | `Error 3159 ... require_secure_transport=ON` |
| `REQUIRED` | connected |
| `VERIFY_CA` / `VERIFY_IDENTITY` with the correct CA | connected |
| `VERIFY_CA` / `VERIFY_IDENTITY` with a wrong CA | `certificate signed by unknown authority` |
| `VERIFY_CA` without `-ssl-ca` (the system certificate store) | rejected |
| `-ssl-ca` only | connected as `VERIFY_CA` |
| `VERIFY_IDENTITY` with `-host 127.0.0.1`, `-host localhost`, and without `-host` | connected |
| `VERIFY_IDENTITY` with `-socket` | rejected before connecting |
| the `[client]` group of my.cnf, and the precedence of the options | as expected |
| deploying and `-import` without `-dry-run` | the schema was applied over TLS |

**mysql:5.7**

| case | result |
| --- | --- |
| `PREFERRED` / `REQUIRED` / `VERIFY_CA` | connected (all of them fail without the second commit) |
| `PREFERRED` with a user created by `REQUIRE SSL` | connected, so the connection is actually encrypted |
| `DISABLED` with the same user | rejected by the server |

**mariadb:10.11** (`have_ssl` is `DISABLED`)

| case | result |
| --- | --- |
| the default (`PREFERRED`) | connected, falling back to plaintext |
| `REQUIRED` | `TLS requested but server does not support TLS` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
