### PR TITLE
fix: ignore the white spaces before the equal sign in my.cnf

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,7 @@ Changes
 ## [unreleased]
 
 - support removing indexes without their names [#68](https://github.com/shogo82148/schemalex-deploy/pull/68)
+- fix ignoring the white spaces before the equal sign in my.cnf [#221](https://github.com/shogo82148/schemalex-deploy/pull/221)
 
 ## [v0.0.7] - 2022-09-08
 

--- a/mycnf/decode.go
+++ b/mycnf/decode.go
@@ -178,7 +178,9 @@ LOOP:
 		buf.WriteRune(unicode.ToLower(ch))
 		p.Read()
 	}
-	return buf.String()
+	// white spaces are allowed around the equal sign.
+	// https://dev.mysql.com/doc/refman/8.0/en/option-files.html
+	return strings.TrimRightFunc(buf.String(), isWhitespace)
 }
 
 func (p *parser) ParseOptionValue() string {

--- a/mycnf/decode_test.go
+++ b/mycnf/decode_test.go
@@ -48,6 +48,30 @@ func TestUnmarshal(t *testing.T) {
 			},
 		},
 		{
+			in: "[group]\nkey = value\n",
+			want: MyCnf{
+				"group": map[string]string{
+					"key": "value",
+				},
+			},
+		},
+		{
+			in: "[group]\nkey\t=\tvalue\n",
+			want: MyCnf{
+				"group": map[string]string{
+					"key": "value",
+				},
+			},
+		},
+		{
+			in: "[group]\nkey \n",
+			want: MyCnf{
+				"group": map[string]string{
+					"key": "",
+				},
+			},
+		},
+		{
 			in: "[group]\nkey=\\n\\r\\t\\b\\s\\\"\\'\\\\\n",
 			want: MyCnf{
 				"group": map[string]string{

--- a/mycnf/decode_test.go
+++ b/mycnf/decode_test.go
@@ -64,6 +64,30 @@ func TestUnmarshal(t *testing.T) {
 			},
 		},
 		{
+			in: "[group]\nkey   =   value\n",
+			want: MyCnf{
+				"group": map[string]string{
+					"key": "value",
+				},
+			},
+		},
+		{
+			in: "[group]\n key=value\n",
+			want: MyCnf{
+				"group": map[string]string{
+					"key": "value",
+				},
+			},
+		},
+		{
+			in: "[group]\n \t key \t = \t value \t \n",
+			want: MyCnf{
+				"group": map[string]string{
+					"key": "value",
+				},
+			},
+		},
+		{
 			in: "[group]\nkey \n",
 			want: MyCnf{
 				"group": map[string]string{


### PR DESCRIPTION
以下の仕様が実装されず、次のような .my.cnf の database のように
=の左側にスペースがあるオプションを読み取れない不具合を修正しました。

```
[client]
user= user
password= "user"
host= 127.0.0.1
port= 3306
database = user_db
EOF
```


> Leading and trailing spaces are automatically deleted from option names and values.
> https://dev.mysql.com/doc/refman/8.4/en/option-files.html


## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `my.cnf` parsing when spaces or tabs appear around the equals sign.
  * Correctly handles key-only entries with trailing whitespace.
  * Normalizes parsed option names and values for more reliable configuration loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->