### PR TITLE
drop support of CentOS 7

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -75,6 +75,7 @@ nfpms:
     bindir: /usr/bin
 
 blobs:
+  # Amazon Linux 2
   - provider: s3
     bucket: shogo82148-rpm-temporary
     ids: [package-amd64]
@@ -83,6 +84,8 @@ blobs:
     bucket: shogo82148-rpm-temporary
     ids: [package-arm64]
     directory: amazonlinux/2/aarch64/schemalex-deploy
+
+  # Amazon Linux 2023
   - provider: s3
     bucket: shogo82148-rpm-temporary
     ids: [package-amd64]
@@ -91,14 +94,8 @@ blobs:
     bucket: shogo82148-rpm-temporary
     ids: [package-arm64]
     directory: amazonlinux/2023/aarch64/schemalex-deploy
-  - provider: s3
-    bucket: shogo82148-rpm-temporary
-    ids: [package-amd64]
-    directory: centos/7/x86_64/schemalex-deploy
-  - provider: s3
-    bucket: shogo82148-rpm-temporary
-    ids: [package-arm64]
-    directory: centos/7/aarch64/schemalex-deploy
+
+  # AlmaLinux 8
   - provider: s3
     bucket: shogo82148-rpm-temporary
     ids: [package-amd64]
@@ -107,6 +104,8 @@ blobs:
     bucket: shogo82148-rpm-temporary
     ids: [package-arm64]
     directory: almalinux/8/aarch64/schemalex-deploy
+
+  # AlmaLinux 9
   - provider: s3
     bucket: shogo82148-rpm-temporary
     ids: [package-amd64]
@@ -115,6 +114,8 @@ blobs:
     bucket: shogo82148-rpm-temporary
     ids: [package-arm64]
     directory: almalinux/9/aarch64/schemalex-deploy
+
+  # Rocky Linux 8
   - provider: s3
     bucket: shogo82148-rpm-temporary
     ids: [package-amd64]
@@ -123,6 +124,8 @@ blobs:
     bucket: shogo82148-rpm-temporary
     ids: [package-arm64]
     directory: rockylinux/8/aarch64/schemalex-deploy
+
+  # Rocky Linux 9
   - provider: s3
     bucket: shogo82148-rpm-temporary
     ids: [package-amd64]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release configuration labels for Amazon Linux, AlmaLinux, and Rocky Linux versions.
  * Removed CentOS 7 release uploads for amd64 and arm64 architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->